### PR TITLE
add `flutter pub get` that also generates the translation files

### DIFF
--- a/src/ui/accessibility-and-internationalization/internationalization.md
+++ b/src/ui/accessibility-and-internationalization/internationalization.md
@@ -262,7 +262,7 @@ complete the following instructions:
    }
    ```
 
-6. Now, run `flutter run` and codegen takes place automatically.
+6. Now, run `flutter pub get` or `flutter run` and codegen takes place automatically.
    You should find generated files in
    `${FLUTTER_PROJECT}/.dart_tool/flutter_gen/gen_l10n`.
    Alternatively, you can also run `flutter gen-l10n` to


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:
calling `flutter pub get` also generates the translation files so that `flutter run` is not the only solution to generate the files

_Issues fixed by this PR (if any):_

## Presubmit checklist

- [X] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [X] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [X] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/main/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
